### PR TITLE
Feedback widget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ jobs:
     permissions:
       id-token: write # Needed for auth with Deno Deploy
       contents: read # Needed to clone the repository
+    
+    env:
+      GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+      GITHUB_INSTALLATION_ID: ${{ secrets.GH_INSTALLATION_ID }}
+      GITHUB_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
 
     steps:
       - name: Clone repository

--- a/islands/IssueButton.tsx
+++ b/islands/IssueButton.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect } from "preact/hooks";
+
+const ISSUE_TYPES = [
+  { label: "Bug Report", color: "bug", description: "Something isn't working" },
+  { label: "Feature Request", color: "enhancement", description: "Suggest an idea" },
+  { label: "Question", color: "question", description: "Ask a question" }
+];
+
+const BUG_TEMPLATE = (data: any) => `
+### Description
+${data.description}
+
+### Steps to Reproduce
+${data.steps}
+
+### Expected Behavior
+${data.expected}
+
+### Actual Behavior
+${data.actual}
+
+### Environment
+- **Browser**: ${data.browser}
+- **Operating System**: ${data.os}
+- **Validator Version**: ${data.version}
+
+${data.githubUsername ? `\nReported by: @${data.githubUsername}` : ''}
+`;
+
+const BASIC_TEMPLATE = (data: any) => `
+### Description
+${data.description}
+
+### Additional Information
+- **Browser**: ${data.browser}
+- **Operating System**: ${data.os}
+- **Validator Version**: ${data.version}
+
+${data.githubUsername ? `\nReported by: @${data.githubUsername}` : ''}
+`;
+
+export default function IssueButton() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [issueType, setIssueType] = useState(ISSUE_TYPES[0].label);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [browserInfo, setBrowserInfo] = useState('');
+  const [githubUsername, setGithubUsername] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [submittedIssueUrl, setSubmittedIssueUrl] = useState('');
+
+  const isBugReport = issueType === "Bug Report";
+
+  useEffect(() => {
+    setBrowserInfo(navigator.userAgent);
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError('');
+
+    const templateData = {
+      description,
+      browser: browserInfo,
+      os: navigator.platform,
+      version: '1.0.0',
+      steps,
+      expected,
+      actual,
+      githubUsername
+    };
+
+    const body = isBugReport 
+      ? BUG_TEMPLATE(templateData)
+      : BASIC_TEMPLATE(templateData);
+    
+    try {
+      const response = await fetch('/api/github/issues', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          title,
+          body,
+          labels: [issueType.toLowerCase()]
+        })
+      });
+
+      if (response.ok) {
+        const issueData = await response.json();
+        setSubmittedIssueUrl(issueData.html_url);
+        resetForm();
+      } else {
+        const errorData = await response.text();
+        setError(`Failed to create issue: ${errorData}`);
+      }
+    } catch (err) {
+      console.error('Failed to create issue:', err);
+      setError('Failed to create issue. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const resetForm = () => {
+    setTitle('');
+    setDescription('');
+    setSteps('');
+    setExpected('');
+    setActual('');
+    setGithubUsername('');
+    setIssueType(ISSUE_TYPES[0].label);
+  };
+
+  const handleClose = () => {
+    setIsModalOpen(false);
+    setSubmittedIssueUrl('');
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsModalOpen(true)}
+        class="bg-blue-500 hover:bg-blue-700 text-white text-sm py-1 px-3 rounded mb-1"
+      >
+        Provide Feedback
+      </button>
+
+      {isModalOpen && (
+        <div class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 mb-1">
+          <div class="bg-white rounded-lg w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <div class="p-6">
+              <div class="flex justify-between items-center mb-4">
+                <h2 class="text-xl font-bold">
+                  {submittedIssueUrl ? 'Feedback Submitted' : 'Provide Feedback'}
+                </h2>
+                <button 
+                  onClick={handleClose}
+                  class="text-gray-500 hover:text-gray-700"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {submittedIssueUrl ? (
+                <div class="space-y-4">
+                  <p>
+                    Your feedback has been submitted successfully! You can view and track your issue at:
+                  </p>
+                  <a 
+                    href={submittedIssueUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:text-blue-800 block break-all"
+                  >
+                    {submittedIssueUrl}
+                  </a>
+                  <p>
+                    Feel free to make any additional comments or follow the issue through your GitHub account.
+                  </p>
+                  <button
+                    onClick={handleClose}
+                    class="w-full py-2 px-4 rounded-md text-white font-medium bg-blue-600 hover:bg-blue-700"
+                  >
+                    Close
+                  </button>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit} class="space-y-4">
+                  <div>
+                    <label class="block text-sm font-medium mb-1">Issue Type</label>
+                    <select
+                      value={issueType}
+                      onChange={(e) => setIssueType(e.target.value)}
+                      class="w-full p-2 border rounded-md"
+                    >
+                      {ISSUE_TYPES.map((type) => (
+                        <option key={type.label} value={type.label}>
+                          {type.label} - {type.description}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium mb-1">Title</label>
+                    <input
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      class="w-full p-2 border rounded-md"
+                      placeholder="Brief summary of the issue"
+                      required
+                    />
+                  </div>
+                  
+                  <div>
+                    <label class="block text-sm font-medium mb-1">Description</label>
+                    <textarea
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      class="w-full p-2 border rounded-md h-24"
+                      placeholder="Detailed description of the issue"
+                      required
+                    />
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium mb-1">
+                      GitHub Username (optional)
+                    </label>
+                    <input
+                      type="text"
+                      value={githubUsername}
+                      onChange={(e) => setGithubUsername(e.target.value)}
+                      class="w-full p-2 border rounded-md"
+                      placeholder="username"
+                    />
+                  </div>
+
+                  {isBugReport && (
+                    <>
+                      <div>
+                        <label class="block text-sm font-medium mb-1">Steps to Reproduce</label>
+                        <textarea
+                          value={steps}
+                          onChange={(e) => setSteps(e.target.value)}
+                          class="w-full p-2 border rounded-md h-24"
+                          placeholder="1. First step&#10;2. Second step&#10;3. ..."
+                          
+                        />
+                      </div>
+
+                      <div class="grid grid-cols-2 gap-4">
+                        <div>
+                          <label class="block text-sm font-medium mb-1">Expected Behavior</label>
+                          <textarea
+                            value={expected}
+                            onChange={(e) => setExpected(e.target.value)}
+                            class="w-full p-2 border rounded-md h-24"
+                            placeholder="What should happen?"
+                            
+                          />
+                        </div>
+
+                        <div>
+                          <label class="block text-sm font-medium mb-1">Actual Behavior</label>
+                          <textarea
+                            value={actual}
+                            onChange={(e) => setActual(e.target.value)}
+                            class="w-full p-2 border rounded-md h-24"
+                            placeholder="What actually happened?"
+                            
+                          />
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {error && (
+                    <div class="text-red-600 text-sm p-2 bg-red-50 rounded">
+                      {error}
+                    </div>
+                  )}
+                  
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    class={`w-full py-2 px-4 rounded-md text-white font-medium 
+                      ${isSubmitting ? 'bg-gray-400' : 'bg-blue-600 hover:bg-blue-700'}`}
+                  >
+                    {isSubmitting ? 'Creating...' : 'Submit Feedback'}
+                  </button>
+                </form>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/islands/Output.tsx
+++ b/islands/Output.tsx
@@ -187,7 +187,7 @@ export default function Output({ issues, validationComplete, validationResult, s
                       <summary>
                         {file.file.path}
                       </summary>
-                      {file.evidence && 
+                      {file.evidence != "" && 
                         <div class=' border border-black border-solid mb-6 p-6'>
                           {file.evidence}
                         </div>

--- a/routes/api/github/issues.ts
+++ b/routes/api/github/issues.ts
@@ -1,0 +1,55 @@
+import { Handlers } from "$fresh/server.ts";
+import { createAppAuth } from "https://esm.sh/@octokit/auth-app";
+
+
+export const handler: Handlers = {
+  async POST(req) {
+    const APP_ID = Deno.env.get("GH_APP_ID");
+    const PRIVATE_KEY = Deno.env.get("GH_PRIVATE_KEY");
+    const INSTALLATION_ID = Deno.env.get("GH_INSTALLATION_ID");
+
+    if (!APP_ID || !PRIVATE_KEY || !INSTALLATION_ID) {
+      return new Response("Missing required environment variables", { 
+        status: 500,
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          appId: !!APP_ID,
+          privateKey: !!PRIVATE_KEY,
+          installationId: !!INSTALLATION_ID
+        })
+      });
+    }
+
+    try {
+        const auth = createAppAuth({
+            appId: APP_ID,
+            privateKey: PRIVATE_KEY,
+            installationId: INSTALLATION_ID
+          });
+
+        const { token } = await auth({ type: "installation" });
+
+        const response = await fetch('https://api.github.com/repos/psych-ds/psychds-validator-web/issues', {
+            method: 'POST',
+            headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+            },
+            body: req.body
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            return new Response(error, { status: response.status });
+        }
+
+        return new Response(JSON.stringify(await response.json()), {
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (error) {
+        return new Response(error.message, { status: 500 });
+    }
+  },
+};

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,6 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { Handlers } from "$fresh/server.ts";
 import Validator from "../islands/Validator.tsx";
+import IssueButton from "../islands/IssueButton.tsx";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -15,15 +16,18 @@ export default function Home() {
   return (
     <div id="root">
       <nav class="navbar navbar-dark bg-black fixed top-0 h-8 w-full">
-          <div class=" pl-16">
-              <a
-                class="text-lg navbar-brand text-white mr-auto p-1 pt-2 pb-2 "
-                href="https://github.com/psych-ds/psychds-validator"
-                target="_blank">
-                Psych-DS Validator
-              </a>
-          </div>
-        </nav>
+        <div class="container pl-16 pr-auto text-left flex justify-between items-center">
+          <a
+            class="text-lg navbar-brand text-white p-1"
+            href="https://github.com/psych-ds/psychds-validator"
+            target="_blank"
+          >
+            Psych-DS Validator
+          </a>
+          <IssueButton />
+        </div>
+        
+      </nav>
       <div class="pt-12 mr-auto ml-auto">
         <Validator />
       </div>


### PR DESCRIPTION
# Add Feedback Widget to Web Validator

## Overview
This PR adds a feedback widget to the Psych-DS web validator that allows users to submit issues directly to the GitHub repository through a modal interface. The widget uses GitHub's API via a GitHub App for authentication and issue creation.

## Features
- Added "Provide Feedback" button in the navbar
- Modal interface with forms for different types of feedback:
 - Bug reports (with structured fields for reproduction steps)
 - Feature requests
 - Questions
- Optional GitHub username field for @mentions in issues
- Automatic collection of environment information
- Success confirmation with direct link to created issue
- Secure GitHub App authentication for issue creation

## Technical Details
- Created new API route for GitHub integration
- Implemented GitHub App authentication flow
- Added GitHub credentials management via environment variables
- Updated deployment workflow to use GitHub secrets